### PR TITLE
补充 cgrep 的链接和说明

### DIFF
--- a/weekly/2020-03-18.md
+++ b/weekly/2020-03-18.md
@@ -79,7 +79,7 @@ EuroLLVM'20 [由于疫情正式取消](http://lists.llvm.org/pipermail/llvm-dev/
 
 ORC JIT Weekly #8 [按时发布了](http://lists.llvm.org/pipermail/llvm-dev/2020-March/139938.html).
 
-一个专门针对C代码文件的 cgrep 被公开。（不知道会有人用么？）
+一个专门针对C代码文件的 [cgrep](https://github.com/bloodstalker/cgrep) 被公开。（不知道会有人用么？）（注：不是[这个 cgrep](https://awgn.github.io/cgrep/) 。）
 > Farzad Sadeghi [announced cgrep](http://lists.llvm.org/pipermail/cfe-dev/2020-March/064836.html), a
 grep-like tool for C language source files.
 


### PR DESCRIPTION
类似工具的名字已经被别的项目（而且不止是 C 能用）占了，还不太好找，有必要补充一下。