### PR TITLE
Add N313 GNU and QEMU-RISCV News

### DIFF
--- a/weekly-2025/2025-07-02.md
+++ b/weekly-2025/2025-07-02.md
@@ -8,11 +8,50 @@
 
 ### GCC
 
+- [COMMITTED 01/40] ada: Adjust comparisons in if-statements according to coding style
+  https://gcc.gnu.org/pipermail/gcc-patches/2025-June/688050.html
+
+- [PATCH] x86: Preserve frame pointer for no_callee_saved_registers attribute
+  https://gcc.gnu.org/pipermail/gcc-patches/2025-June/687953.html
+
+- [PATCH v2 0/4] RISC-V: Combine vec_duplicate + vssubu.vv to vssubu.vx on GR2VR cost
+  https://gcc.gnu.org/pipermail/gcc-patches/2025-June/687832.html
+
+- [PATCH v3 0/6] LoongArch: Add support for _BitInt [PR117599]
+  https://gcc.gnu.org/pipermail/gcc-patches/2025-June/687783.html
+
+- [PATCH 1/8] libstdc++: Directly implement ranges::heap algos [PR100795]
+  https://gcc.gnu.org/pipermail/gcc-patches/2025-June/687744.html
+
+- [PATCH v2] RISC-V: Updated march , that aligned with mips-p8700
+  https://gcc.gnu.org/pipermail/gcc-patches/2025-July/688244.html
+
+- [PATCH v3 0/4] Support unsigned scalar SAT_MUL from uint128_t
+  https://gcc.gnu.org/pipermail/gcc-patches/2025-July/688289.html
+
 ### BINUTILS
+
+- [PATCH v3 00/11] s390: Support to generate .sframe in assembler and linker
+  https://sourceware.org/pipermail/binutils/2025-June/142010.html
+
+- [PATCH] LoongArch: Allow to relax instructions into NOPs after handling alignment
+  https://sourceware.org/pipermail/binutils/2025-June/142039.html
+
+- [PATCH v4 00/22] AArch64 AEABI build attributes (a.k.a. object attributes v2)
+  https://sourceware.org/pipermail/binutils/2025-July/142104.html
 
 ### GDB
 
+- GDB 17.1 release -- 2025-06-27 Update
+  https://sourceware.org/pipermail/gdb-patches/2025-June/219034.html
+
+- [PATCH 0/3] extending the amd64 prologue analyzer
+  https://sourceware.org/pipermail/gdb-patches/2025-July/219068.html
+
 ### GLIBC
+
+- [PATCH v2 0/5] termios: _SPEED_MAX and _BAUD_MAX, manual improvements
+  https://sourceware.org/pipermail/libc-alpha/2025-June/168284.html
 
 ### LLVM/Clang/LLDB/LLD
 
@@ -20,6 +59,12 @@
 [Alex Bradbury](https://www.linkedin.com/in/alex-bradbury/) 大哥持续稳定输出。
 
 ### QEMU (RISC-V)
+
+- [PATCH v3 0/2] Add S-mode checks for delegation-related CSRs
+  https://lists.nongnu.org/archive/html/qemu-devel/2025-06/msg04801.html
+
+- [PATCH v5 00/11] riscv: Add support for MIPS P8700 CPU
+  https://lists.nongnu.org/archive/html/qemu-devel/2025-07/msg01071.html
 
 ### RISC-V in China
 


### PR DESCRIPTION
Add N313 GNU and QEMU-RISCV News. 
In addition, should we add newlib's news to the glibc section?