### PR TITLE
Add N353 QEMU News

### DIFF
--- a/weekly-2026/2026-04-08.md
+++ b/weekly-2026/2026-04-08.md
@@ -54,6 +54,48 @@ https://github.com/hellogcc/osdt-weekly/tree/master/weekly-2026
 
 ### QEMU
 
+- [PATCH v5 0/6] target/riscv: Implement Smsdid and Smmpt extension
+  https://lore.kernel.org/qemu-devel/20260408140635.42546-1-zhiwei_liu@linux.alibaba.com/
+
+- [PATCH v6 0/9] target/riscv: Add Zvfbfa extension support
+  https://lore.kernel.org/qemu-devel/20260402125234.1371897-1-max.chou@sifive.com/
+
+- [PATCH v6 0/7] Add RISC-V big-endian target support
+  https://lore.kernel.org/qemu-devel/20260406154935.144674-1-djordje.todorovic@htecgroup.com/
+
+- [PATCH qemu v2 0/7] Update opentitan uart (part of supporting opentitan version 1)
+  https://lore.kernel.org/qemu-devel/177564643888.23414.7922925369077631439-0@git.sr.ht/
+
+- [PATCH v11 00/21] target/arm: single-binary
+  https://lore.kernel.org/qemu-devel/20260407222208.271838-1-pierrick.bouvier@linaro.org/
+
+- [PATCH v2 00/14] Add ARM64 support for MSHV accelerator
+  https://lore.kernel.org/qemu-devel/20260402-mshv_accel_arm64_supp-v2-0-754895c15e9e@linux.microsoft.com/
+
+- [PATCH v3 00/33] hw/arm: Introduce generic FDT-driven machine
+  https://lore.kernel.org/qemu-devel/20260402215629.745866-1-ruslichenko.r@gmail.com/
+
+- [PATCH v4 00/28] Hexagon system emulation - Part 2/3
+  https://lore.kernel.org/qemu-devel/20260408041953.1899532-1-brian.cain@oss.qualcomm.com/
+
+- [PATCH v4 0/9] Hexagon system emulation - Part 3/3
+  https://lore.kernel.org/qemu-devel/20260408042149.1902796-1-brian.cain@oss.qualcomm.com/
+
+- [PATCH v10 00/30] Secure IPL Support for SCSI Scheme of virtio-blk/virtio-scsi Devices
+  https://lore.kernel.org/qemu-devel/20260402221453.1602899-1-zycai@linux.ibm.com/
+
+- [PATCH 00/15] s390x/pci: Implement migration for emulated devices
+  https://lore.kernel.org/qemu-devel/20260402022921.298818-1-kshk@linux.ibm.com/
+
+- [PATCH v3 00/14] intel_iommu: Enable PASID support for passthrough device
+  https://lore.kernel.org/qemu-devel/20260403035541.18355-1-zhenzhong.duan@intel.com/
+
+- [PATCH v3 00/10] hw/tpm: CRB chunking capability to handle PQC
+  https://lore.kernel.org/qemu-devel/20260406141735.25844-1-armenon@redhat.com/
+
+- [RFC PATCH 00/10] vfio: PCI device passthrough on Apple Silicon Macs
+  https://lore.kernel.org/qemu-devel/20260405072857.66484-1-scottjgo@gmail.com/
+
 ### RISC-V in China
 
 - https://ruyisdk.cn 每日八卦都在这里了。


### PR DESCRIPTION
Add 14 notable QEMU feature patches from the past week:
- RISC-V Smsdid/Smmpt extension, Zvfbfa extension, big-endian target support, OpenTitan UART update
- ARM single-binary (v11), ARM64 MSHV accelerator, generic FDT-driven machine
- Hexagon system emulation Part 2/3 and Part 3/3
- s390x Secure IPL for SCSI scheme, s390x/pci migration for emulated devices
- Intel IOMMU PASID support for passthrough device
- TPM CRB chunking capability for PQC
- vfio PCI device passthrough on Apple Silicon Macs