### PR TITLE
Add N354 QEMU News

### DIFF
--- a/weekly-2026/2026-04-15.md
+++ b/weekly-2026/2026-04-15.md
@@ -65,6 +65,45 @@ https://github.com/hellogcc/osdt-weekly/tree/master/weekly-2026
 
 ### QEMU
 
+- [PATCH v6 0/7] riscv: add initial sdext support
+  https://lore.kernel.org/qemu-devel/cover.1775959096.git.chao.liu.zevorn@gmail.com/
+
+- [PATCH v2 0/4] hw/riscv: Boot setup improvements
+  https://lore.kernel.org/qemu-devel/20260415064838.652297-1-joel@jms.id.au/
+
+- [PATCH v4 00/31] hw/arm/virt: Introduce Tegra241 CMDQV support for accelerated SMMUv3
+  https://lore.kernel.org/qemu-devel/20260415105552.622421-1-skolothumtho@nvidia.com/
+
+- [PATCHv6 00/15] Adding comprehensive support for i.MX8MM EVK board
+  https://lore.kernel.org/qemu-devel/20260414182313.1691519-1-gaurav.sharma_7@nxp.com/
+
+- [PATCH v12 00/15] whpx: i386: bug fixes, feature probing and CPUID
+  https://lore.kernel.org/qemu-devel/20260413205208.50643-1-mohamed@unpredictable.fr/
+
+- [PATCH v3 00/27] monitor: Remove need of per-target handlers
+  https://lore.kernel.org/qemu-devel/20260414003001.97571-1-philmd@linaro.org/
+
+- [PATCH v2 00/17] hw/usb/ehci: Add 64-bit descriptor addressing support
+  https://lore.kernel.org/qemu-devel/20260414080025.3005916-1-jamin_lin@aspeedtech.com/
+
+- [PATCH v2 00/67] ui: add standalone VNC server over D-Bus
+  https://lore.kernel.org/qemu-devel/20260410-qemu-vnc-v2-0-231416f76dc3@redhat.com/
+
+- [PATCH V6 00/14] iothread: Support tracking and querying IOThread holders
+  https://lore.kernel.org/qemu-devel/20260410150457.85190-1-zhangckid@gmail.com/
+
+- [PATCH 00/17] bsd-user: upstream ioctl
+  https://lore.kernel.org/qemu-devel/20260412-ioctl-v1-0-1d998a460560@bsdimp.com/
+
+- [PATCH v4 0/3] improve aio-polling efficiency
+  https://lore.kernel.org/qemu-devel/20260412215011.326196-1-jhkim@linux.ibm.com/
+
+- [PATCH v2] add a refresh_rate option to virtio-gpu
+  https://lore.kernel.org/qemu-devel/20260415-virtio-gpu-refresh-rate-v2-1-b71599d84755@slonk.ing/
+
+- [PATCH] block: add blockdev-attach QMP command
+  https://lore.kernel.org/qemu-devel/20260415173905.71224-1-matthieu@min.io/
+
 ### RISC-V in China
 
 - https://ruyisdk.cn 每日八卦都在这里了。


### PR DESCRIPTION
Add 13 notable QEMU feature patches from the past week:
- RISC-V initial Sdext (Supervisor-mode debug extension) support, hw/riscv boot setup improvements
- ARM Tegra241 CMDQV accelerated SMMUv3, i.MX8MM EVK board comprehensive support
- x86 whpx i386 bug fixes, feature probing and CPUID (v12)
- Monitor remove need of per-target handlers
- hw/usb/ehci 64-bit descriptor addressing support
- ui: standalone VNC server over D-Bus
- iothread tracking and querying holders
- bsd-user upstream ioctl
- Improve aio-polling efficiency
- virtio-gpu refresh_rate option
- block: blockdev-attach QMP command