### PR TITLE
Add N355 QEMU News

### DIFF
--- a/weekly-2026/2026-04-22.md
+++ b/weekly-2026/2026-04-22.md
@@ -22,6 +22,48 @@ https://github.com/hellogcc/osdt-weekly/tree/master/weekly-2026
 
 ### QEMU
 
+- [PATCH 00/14] target/riscv: add support for RISC-V P extension (v0.20 draft)
+  https://lore.kernel.org/qemu-devel/20260417104652.17857-1-xiaoou@iscas.ac.cn/
+
+- [PATCH v6 0/5] Add support for K230 board
+  https://lore.kernel.org/qemu-devel/cover.1776438369.git.chao.liu.zevorn@gmail.com/
+
+- [PATCH v10 0/2] Generate strided vector loads/stores with tcg nodes
+  https://lore.kernel.org/qemu-devel/cover.1776437127.git.chao.liu.zevorn@gmail.com/
+
+- [PATCH v3 00/13] hw/riscv: Add the Tenstorrent Atlantis machine
+  https://lore.kernel.org/qemu-devel/20260421053140.752059-1-joel@jms.id.au/
+
+- [PATCH v4 0/6] Fix Zjpm implementation
+  https://lore.kernel.org/qemu-devel/20260421093715.2995067-1-frank.chang@sifive.com/
+
+- [PATCH v2 0/5] Defer the IOMMU translation and support access_type
+  https://lore.kernel.org/qemu-devel/20260421162912.3295598-1-jim.shu@sifive.com/
+
+- [PATCH 00/37] target/arm: Implement FEAT_FAMINMAX, FEAT_FPMR, FEAT_FP8
+  https://lore.kernel.org/qemu-devel/20260421051346.41106-1-richard.henderson@linaro.org/
+
+- [PATCH v3 0/4] FEAT_RME_GDI initial work
+  https://lore.kernel.org/qemu-devel/20260421-jmac-feat_rme_gdi-v3-0-ecd20c77eae1@linaro.org/
+
+- [PATCH 00/34] Add migration support to the MSHV accelerator
+  https://lore.kernel.org/qemu-devel/20260417105618.3621-1-magnuskulke@linux.microsoft.com/
+
+- [PATCH v2 00/38] WHPX x86 updates for QEMU 11.1
+  https://lore.kernel.org/qemu-devel/20260420104248.86702-1-mohamed@unpredictable.fr/
+
+- [PATCH 0/8] hw/nvme: add basic live migration support
+  https://lore.kernel.org/qemu-devel/20260419130139.15554-1-alexander@mihalicyn.com/
+
+- [PATCH v4 00/21] Add SSP/TSP power control and DRAM remap support for AST2700
+  https://lore.kernel.org/qemu-devel/20260417032837.2664122-1-jamin_lin@aspeedtech.com/
+
+- [PATCH v2 00/13] target/mips: add missing Octeon user-mode support
+  https://lore.kernel.org/qemu-devel/20260421-mips-octeon-missing-insns-v2-v2-0-a0791df188c9@gmail.com/
+
+- [PATCH v15 0/8] virtio-net: live-TAP local migration
+  https://lore.kernel.org/qemu-devel/20260420193846.675844-1-vsementsov@yandex-team.ru/
+
 ### RISC-V in China
 
 - https://ruyisdk.cn 每日八卦都在这里了。


### PR DESCRIPTION
Add 14 notable QEMU feature patches from the past week:
- RISC-V P extension (v0.20 draft) support from ISCAS, K230 board support, strided vector loads/stores TCG codegen, Tenstorrent Atlantis machine, Zjpm pointer masking fix, IOMMU deferred translation
- ARM FEAT_FAMINMAX/FEAT_FPMR/FEAT_FP8 implementation, FEAT_RME_GDI initial work
- MSHV accelerator migration support (34 patches)
- WHPX x86 updates for QEMU 11.1 (38 patches)
- NVMe basic live migration support
- Aspeed AST2700 SSP/TSP power control and DRAM remap
- MIPS Octeon user-mode support
- virtio-net live-TAP local migration (v15)