### PR TITLE
Add N356 QEMU News

### DIFF
--- a/weekly-2026/2026-04-29.md
+++ b/weekly-2026/2026-04-29.md
@@ -22,6 +22,45 @@ https://github.com/hellogcc/osdt-weekly/tree/master/weekly-2026
 
 ### QEMU
 
+- [PATCH v5 0/9] target/riscv: Add RISC-V Zvfofp8min extension support
+  https://lore.kernel.org/qemu-devel/20260427060928.2322570-1-max.chou@sifive.com/
+
+- [PATCH 0/4] Support the true Zicclsm extension
+  https://lore.kernel.org/qemu-devel/20260424102800.24022-1-frank.chang@sifive.com/
+
+- [PATCH v5 0/4] hw/riscv: Server Platform Reference Board
+  https://lore.kernel.org/qemu-devel/20260424191129.1494381-1-daniel.barboza@oss.qualcomm.com/
+
+- [PATCH 0/4] Minor fixes and enhancements of RISC-V AIA devices
+  https://lore.kernel.org/qemu-devel/20260428160103.3551125-1-jim.shu@sifive.com/
+
+- [PATCH v2 00/40] target/arm: Implement FEAT_FP8
+  https://lore.kernel.org/qemu-devel/20260424043014.46305-1-richard.henderson@linaro.org/
+
+- [PATCH 00/16] accel/hvf: Assorted collection of patches queued before v11 release
+  https://lore.kernel.org/qemu-devel/20260423170229.64655-1-philmd@linaro.org/
+
+- [PATCH v5 0/3] hvf: map granule abstraction, configurable IPA, and MAP_FIXED alignment fix
+  https://lore.kernel.org/qemu-devel/20260424000544.9617-1-lucaaamaral@gmail.com/
+
+- [RFC PATCH 00/84] fpu: Export some internals for targets
+  https://lore.kernel.org/qemu-devel/20260426134002.865628-1-richard.henderson@linaro.org/
+
+- [PATCH v6 00/10] Implement MPIPL for PowerNV
+  https://lore.kernel.org/qemu-devel/20260424083837.214947-1-adityag@linux.ibm.com/
+
+- [RFC V3 0/4] LoongArch: Add KVM DINTC support
+  https://lore.kernel.org/qemu-devel/20260427070029.1059386-1-gaosong@loongson.cn/
+
+- [RFC 0/9] QEMU: CXL Type-2 device passthrough via vfio-pci
+  https://lore.kernel.org/qemu-devel/20260427181235.3003865-1-mhonap@nvidia.com/
+
+- [PATCH 0/6] single-binary: deduplicate target_info()
+  https://lore.kernel.org/qemu-devel/20260428234519.1812371-1-pierrick.bouvier@oss.qualcomm.com/
+
+- [PATCH 0/12] qapi: add formal 'intro' section
+  https://lore.kernel.org/qemu-devel/20260423220022.2180059-1-jsnow@redhat.com/
+
 ### RISC-V in China
 
 - https://ruyisdk.cn 每日八卦都在这里了。


### PR DESCRIPTION
Add 13 notable QEMU feature patches from the past week:
- RISC-V Zvfofp8min extension support (FP8 vector), Zicclsm extension, Server Platform Reference Board, AIA device enhancements
- ARM FEAT_FP8 implementation (40 patches)
- HVF assorted patches for v11, HVF map granule abstraction and configurable IPA
- FPU internals export for targets (84 patches)
- PowerNV MPIPL implementation
- LoongArch KVM DINTC support (v3)
- CXL Type-2 device passthrough via vfio-pci
- single-binary: deduplicate target_info()
- QAPI: add formal 'intro' section