### PR TITLE
Add N357 QEMU News

### DIFF
--- a/weekly-2026/2026-05-06.md
+++ b/weekly-2026/2026-05-06.md
@@ -22,6 +22,42 @@ https://github.com/hellogcc/osdt-weekly/tree/master/weekly-2026
 
 ### QEMU
 
+- [PATCH v4 00/13] hw/riscv: Add the Tenstorrent Atlantis machine
+  https://lore.kernel.org/qemu-devel/20260425131721.932250-1-joel@jms.id.au/
+
+- [PATCH 0/2] target/riscv: Update deprecated machines
+  https://lore.kernel.org/qemu-devel/20260430052218.771358-1-alistair.francis@wdc.com/
+
+- [PATCH v4 0/2] Set MISA.[C|X] based on the selected extensions
+  https://lore.kernel.org/qemu-devel/20260424050509.3935180-1-frank.chang@sifive.com/
+
+- [PATCH v3 0/2] Add the implied rules for G and B extensions
+  https://lore.kernel.org/qemu-devel/20260424042946.3875690-1-frank.chang@sifive.com/
+
+- [PATCH v3 00/47] target/arm: Implement FEAT_FP8
+  https://lore.kernel.org/qemu-devel/20260430002046.59739-1-richard.henderson@linaro.org/
+
+- [PATCH v5 00/15] target/arm: add support for MTE4
+  https://lore.kernel.org/qemu-devel/20260504-feat-mte4-v5-0-232a648e63c6@gmail.com/
+
+- [PATCH v21 00/15] HVF: Add support for platform vGIC and nested virtualisation
+  https://lore.kernel.org/qemu-devel/20260429190532.26538-1-mohamed@unpredictable.fr/
+
+- [PATCH v4 00/17] kvm/arm: Introduce a customizable aarch64 KVM host model
+  https://lore.kernel.org/qemu-devel/20260503073541.790215-1-eric.auger@redhat.com/
+
+- [PATCH 0/7] m68k: Add Sun-3 Machine Emulation
+  https://lore.kernel.org/qemu-devel/20260503015756.99176-1-54weasels@gmail.com/
+
+- [PATCH v3 0/8] single-binary: deduplicate target_info()
+  https://lore.kernel.org/qemu-devel/20260430203842.29156-1-pierrick.bouvier@oss.qualcomm.com/
+
+- [PATCH 00/14] Make switchover-ack re-usable and add VFIO precopy REINIT feature
+  https://lore.kernel.org/qemu-devel/20260505081423.28326-1-avihaih@nvidia.com/
+
+- [PATCH 0/6] s390x: Add support for virtio-scsi-pci boot device
+  https://lore.kernel.org/qemu-devel/20260504221613.826825-1-jrossi@linux.ibm.com/
+
 ### RISC-V in China
 
 - https://ruyisdk.cn 每日八卦都在这里了。


### PR DESCRIPTION
- Add QEMU feature patches for N357 weekly (2026-05-06)
- RISC-V patches prioritized: Tenstorrent Atlantis machine v4, Update deprecated machines, Set MISA extensions, Implied rules for G/B extensions
- Also includes ARM FEAT_FP8 v3, MTE4 v5, HVF vGIC v21, KVM host model v4, Sun-3 m68k emulation, single-binary dedup v3, VFIO switchover-ack, and s390x virtio-scsi-pci boot