### PR TITLE
Add N358 QEMU News

### DIFF
--- a/weekly-2026/2026-05-13.md
+++ b/weekly-2026/2026-05-13.md
@@ -22,6 +22,42 @@ https://github.com/hellogcc/osdt-weekly/tree/master/weekly-2026
 
 ### QEMU
 
+- [PATCH v6 0/6] target/riscv: Implement Smsdid and Smmpt extension
+  https://lore.kernel.org/qemu-devel/20260511124705.28161-1-zhiwei_liu@linux.alibaba.com/
+
+- [PATCH v9 0/7] Add RISC-V big-endian target support
+  https://lore.kernel.org/qemu-devel/20260511083819.206216-1-djordje.todorovic@htecgroup.com/
+
+- [PATCH v7 0/5] Add support for K230 board
+  https://lore.kernel.org/qemu-devel/cover.1778516731.git.chao.liu.zevorn@gmail.com/
+
+- [PATCH v2 0/6] hw/riscv: Add support for Milk-V Duo board
+  https://lore.kernel.org/qemu-devel/20260514011528.1263665-1-visitorckw@gmail.com/
+
+- [PATCH v2 0/4] Support the true Zicclsm extension
+  https://lore.kernel.org/qemu-devel/20260513035310.3764218-1-frank.chang@sifive.com/
+
+- [PATCH v2 00/14] target/riscv: remove riscv_cpu_* arrays
+  https://lore.kernel.org/qemu-devel/20260512032926.1978818-1-daniel.barboza@oss.qualcomm.com/
+
+- [PATCH v1] hw/riscv/riscv-iommu: Avoid caching PCI device IDs
+  https://lore.kernel.org/qemu-devel/20260514020637.2819308-1-gaochengbo@bosc.ac.cn/
+
+- [PATCH] target/riscv/kvm: skip FP/Vector sync on KVM_PUT_RUNTIME_STATE
+  https://lore.kernel.org/qemu-devel/20260513100447.2167615-1-mengzhuo@iscas.ac.cn/
+
+- [PATCH] target/riscv: Update the local interrupt mask
+  https://lore.kernel.org/qemu-devel/20260513051841.1671987-1-alistair.francis@wdc.com/
+
+- [PATCH v6 00/15] hw/arm: add Beckhoff CX7200 board
+  https://lore.kernel.org/qemu-devel/20260513105517.146706-1-corvin.koehne@gmail.com/
+
+- [PATCH v7 00/35] target/mips: add missing Octeon user-mode support
+  https://lore.kernel.org/qemu-devel/20260514-mips-octeon-missing-insns-v2-v7-0-226686be4ce1@gmail.com/
+
+- [PATCH 0/1] hw/scsi: add initial SCSI tape device emulation
+  https://lore.kernel.org/qemu-devel/20260513024454.75840-1-emmanuelugwu121@gmail.com/
+
 ### RISC-V in China
 
 - https://ruyisdk.cn 每日八卦都在这里了。


### PR DESCRIPTION
- Add QEMU section for N358 (2026-05-13) weekly
- RISC-V patches prioritized: Smsdid/Smmpt v6, big-endian v9, K230 v7, Zicclsm v2, Milk-V Duo v2, riscv_cpu_* cleanup, IOMMU opt, KVM opt, local interrupt fix
- Also includes Beckhoff CX7200 ARM board, MIPS Octeon user-mode, and SCSI tape emulation patches