### PR TITLE
Add N359 QEMU News

### DIFF
--- a/weekly-2026/2026-05-20.md
+++ b/weekly-2026/2026-05-20.md
@@ -22,6 +22,48 @@ https://github.com/hellogcc/osdt-weekly/tree/master/weekly-2026
 
 ### QEMU
 
+- [PATCH] target/riscv,disas/riscv: add insn len encodings > 64 bit
+  https://lists.nongnu.org/archive/html/qemu-devel/2026-05/msg05253.html
+
+- [PATCH] disas/riscv.c: add 'cbo' insns to disassembler
+  https://lists.nongnu.org/archive/html/qemu-devel/2026-05/msg04762.html
+
+- [PATCH] hw: misc: Implement Microchip mpfs ioscb PLLs and sysreg clock dividers
+  https://lists.nongnu.org/archive/html/qemu-devel/2026-05/msg03369.html
+
+- [PATCH 00/40] Make HMP optional (and later standalone)
+  https://lists.nongnu.org/archive/html/qemu-devel/2026-05/msg05427.html
+
+- [PATCH v4 1/1] qemu-img: add sub-command --remove-all to 'qemu-img bitmap'
+  https://lists.nongnu.org/archive/html/qemu-devel/2026-05/msg05472.html
+
+- [PATCH v2 00/37] bsd-user: Upstream most of the remaining system calls
+  https://lists.nongnu.org/archive/html/qemu-devel/2026-05/msg04326.html
+
+- [PATCHv1 0/7] hw/arm: Adding Cortex-M7 Asymmetric Multiprocessing boot support for i.MX8MP
+  https://lists.nongnu.org/archive/html/qemu-devel/2026-05/msg04732.html
+
+- [PATCH v3 0/3] hw/arm/aspeed: add anacapa-bmc machine
+  https://lists.nongnu.org/archive/html/qemu-devel/2026-05/msg04725.html
+
+- [PATCH 0/2] target/arm: implement FEAT_RNG_TRAP
+  https://lists.nongnu.org/archive/html/qemu-devel/2026-05/msg04633.html
+
+- [PATCH v2 0/4] target/arm: Implement FEAT_CMPBR
+  https://lists.nongnu.org/archive/html/qemu-devel/2026-05/msg04300.html
+
+- [PATCH 0/3] target/arm: add support for Cortex-M pointer authentication code
+  https://lists.nongnu.org/archive/html/qemu-devel/2026-05/msg04275.html
+
+- [PATCH 0/4] target/loongarch: add LVZ support for TCG
+  https://lists.nongnu.org/archive/html/qemu-devel/2026-05/msg04412.html
+
+- [PATCH v3 0/6] ppc/spapr: Add RTAS error injection support for VFIO EEH
+  https://lists.nongnu.org/archive/html/qemu-devel/2026-05/msg05010.html
+
+- [PATCH v4 0/5] initial support for yosemite v4
+  https://lists.nongnu.org/archive/html/qemu-devel/2026-05/msg03612.html
+
 ### RISC-V in China
 
 - https://ruyisdk.cn 每日八卦都在这里了。


### PR DESCRIPTION
- Add QEMU section for N359 (2026-05-20) weekly
- RISC-V patches prioritized: instruction length encodings > 64 bit, CBO disassembler, and Microchip MPFS IOSCB PLL/sysreg clock dividers
- Also includes HMP optionalization, qemu-img bitmap remove-all, bsd-user syscall upstreaming, i.MX8MP Cortex-M7 AMP boot, Anacapa BMC machine, ARM FEAT_RNG_TRAP/CMPBR/Cortex-M PAC, LoongArch LVZ, ppc/spapr RTAS error injection, and Yosemite v4 support