### PR TITLE
Add N365 QEMU News

### DIFF
--- a/weekly-2026/2026-07-01.md
+++ b/weekly-2026/2026-07-01.md
@@ -22,6 +22,69 @@ https://github.com/hellogcc/osdt-weekly/tree/master/weekly-2026
 
 ### QEMU
 
+- [PATCH v3 0/5] Support the true Zicclsm extension
+  https://lists.nongnu.org/archive/html/qemu-riscv/2026-06/msg00570.html
+
+- [PATCH v1] riscv/virt: Add secondary UART
+  https://lists.nongnu.org/archive/html/qemu-riscv/2026-06/msg00519.html
+
+- [PATCH v2] target/riscv: Report QEMU CPU archid as 42
+  https://lists.nongnu.org/archive/html/qemu-riscv/2026-06/msg00501.html
+
+- [PATCH 0/2] hw/scsi/ncr53c710: rewrite to support HP-UX, Linux and NetBSD
+  https://lists.nongnu.org/archive/html/qemu-devel/2026-06/msg07982.html
+
+- [PATCH 0/4] Add Support for AMD EPYC Zen 6 CPU Model
+  https://lists.nongnu.org/archive/html/qemu-devel/2026-06/msg07846.html
+
+- [PATCH v4 0/2] hw/nvme: add monitor commands for inspecting state
+  https://lists.nongnu.org/archive/html/qemu-devel/2026-06/msg07772.html
+
+- [PATCH 0/3] hw/display: add vhost-user-media device
+  https://lists.nongnu.org/archive/html/qemu-devel/2026-06/msg07765.html
+
+- [RFC PATCH v2 0/7] migration: fast snapshot load
+  https://lists.nongnu.org/archive/html/qemu-devel/2026-06/msg07709.html
+
+- [PATCH 0/2] hw/ufs: Complete UFSHCI 4.1 link bring-up and MCQ tagging
+  https://lists.nongnu.org/archive/html/qemu-devel/2026-06/msg07209.html
+
+- [PATCH 0/1] hw/arm: Make xlnx-zcu102 direct Linux boot usable
+  https://lists.nongnu.org/archive/html/qemu-devel/2026-06/msg07165.html
+
+- [PATCH v2] target/arm: Implement and enable FEAT_SSVE_FEXPA for -cpu max
+  https://lists.nongnu.org/archive/html/qemu-devel/2026-06/msg07071.html
+
+- [PATCH v3 0/9] hw/audio/virtio-sound: basic migration support
+  https://lists.nongnu.org/archive/html/qemu-devel/2026-06/msg07001.html
+
+- [PATCH v2] target/ppc: Expose the TB offset of the guest in QEMU monitor
+  https://lists.nongnu.org/archive/html/qemu-devel/2026-06/msg06907.html
+
+- [PATCH 00/15] target/arm: Implement FEAT_SME_MOP4
+  https://lists.nongnu.org/archive/html/qemu-devel/2026-06/msg06817.html
+
+- [PATCH v2 00/39] Make HMP optional (and later standalone)
+  https://lists.nongnu.org/archive/html/qemu-devel/2026-06/msg06761.html
+
+- [PATCH 0/4] hw/arm/fsl-imx8mp: Add inital FlexCAN support
+  https://lists.nongnu.org/archive/html/qemu-devel/2026-07/msg00266.html
+
+- [PATCH v12 00/35] Secure IPL Support for SCSI Scheme of virtio-blk/virtio-scsi Devices
+  https://lists.nongnu.org/archive/html/qemu-devel/2026-07/msg00223.html
+
+- [PATCH v5 0/8] hw/sensor: Add new device emulation for TI ADC128D818
+  https://lists.nongnu.org/archive/html/qemu-devel/2026-07/msg00212.html
+
+- [PATCH 0/3] hw/i386/microvm: add uefi-vars-sysbus support via platform bus
+  https://lists.nongnu.org/archive/html/qemu-devel/2026-07/msg00158.html
+
+- [PATCH v3 0/2] s390x/kvm: Add ASTFLE facility 2 for nested virtualization
+  https://lists.nongnu.org/archive/html/qemu-devel/2026-07/msg00048.html
+
+- [PATCH v4 0/3] ppc/kvm: Handle CPU compatibility mode correctly for nested guests
+  https://lists.nongnu.org/archive/html/qemu-devel/2026-07/msg00013.html
+
 ### RISC-V in China
 
 - https://ruyisdk.cn 每日八卦都在这里了。


### PR DESCRIPTION
Added Weekly status of upstream feature patches for QEMU as of 2026-07-01.