### PR TITLE
Add N368 QEMU News

### DIFF
--- a/weekly-2026/2026-07-22.md
+++ b/weekly-2026/2026-07-22.md
@@ -22,6 +22,102 @@ https://github.com/hellogcc/osdt-weekly/tree/master/weekly-2026
 
 ### QEMU
 
+- [PATCH 0/7] K230: add gsdma and decomp_gzip
+  https://lists.nongnu.org/archive/html/qemu-riscv/2026-07/msg00967.html
+
+- [PATCH 0/5] target/riscv: Add SiFive Xsfvqmaccdod/Xsfvqmaccqoq int8 matmul extensions
+  https://lists.nongnu.org/archive/html/qemu-riscv/2026-07/msg00954.html
+
+- [PATCH] feat(char): implement DesignWare 8250-compatible UART
+  https://lists.nongnu.org/archive/html/qemu-riscv/2026-07/msg00953.html
+
+- [PATCH v5 00/10] riscv: add initial RPMI virt support
+  https://lists.nongnu.org/archive/html/qemu-riscv/2026-07/msg00940.html
+
+- [PATCH v2 0/2] hw/riscv/k230: add the K230 Reset Management Unit
+  https://lists.nongnu.org/archive/html/qemu-devel/2026-07/msg05478.html
+
+- [PATCH v3] riscv/virt: Add optional UART1
+  https://lists.nongnu.org/archive/html/qemu-riscv/2026-07/msg00763.html
+
+- [PATCH v2 00/18] target/riscv: Add support for RISC-V P
+  https://lists.nongnu.org/archive/html/qemu-riscv/2026-07/msg00697.html
+
+- [PATCH v2] tcg/riscv: raise VLEN limit to the specification's maximum
+  https://lists.nongnu.org/archive/html/qemu-riscv/2026-07/msg00694.html
+
+- [PATCH 0/3] riscv: Add K230 DDR controller and PHY models
+  https://lists.nongnu.org/archive/html/qemu-riscv/2026-07/msg00671.html
+
+- [PATCH v6 00/11] Add SSP/TSP power control and DRAM remap support for AST2700
+  https://lists.nongnu.org/archive/html/qemu-devel/2026-07/msg06343.html
+
+- [PATCH v5] hw/i2c: Add remote I2C master with host CUSE bridge
+  https://lists.nongnu.org/archive/html/qemu-devel/2026-07/msg06262.html
+
+- [PATCH 00/20] target/arm: Implement FEAT_SVE_{BFSCALE,BitPerm,AES2}
+  https://lists.nongnu.org/archive/html/qemu-devel/2026-07/msg06054.html
+
+- [RFC PATCH 0/4] virtio: SQ/CQ doorbell polling for vhost-scsi
+  https://lists.nongnu.org/archive/html/qemu-devel/2026-07/msg05802.html
+
+- [PATCH v2 0/5] hw/cxl: Host-only default CFMW restrictions and per-window options
+  https://lists.nongnu.org/archive/html/qemu-devel/2026-07/msg05797.html
+
+- [PATCH v3 00/13] hexagon: add semihosting support
+  https://lists.nongnu.org/archive/html/qemu-devel/2026-07/msg05721.html
+
+- [PATCH v4 0/2] hw/misc/applesmc: fix GET_KEY_BY_INDEX iteration and populate Apple SMC key set
+  https://lists.nongnu.org/archive/html/qemu-devel/2026-07/msg05708.html
+
+- [PATCH] usb/xhci: implement Event Ring Full handling
+  https://lists.nongnu.org/archive/html/qemu-devel/2026-07/msg05490.html
+
+- [PATCH for-11.2 0/6] target/arm: Implement FEAT_SME2p2
+  https://lists.nongnu.org/archive/html/qemu-devel/2026-07/msg05471.html
+
+- [PATCH 0/9] ati-vga: Implement r100 CP engine
+  https://lists.nongnu.org/archive/html/qemu-devel/2026-07/msg05461.html
+
+- [PATCH] qga: implement 'guest-get-diskstats' for FreeBSD
+  https://lists.nongnu.org/archive/html/qemu-devel/2026-07/msg05460.html
+
+- [PATCH 0/2] hw/usb/dev-hid: Apple Magic Keyboard and Mighty Mouse emulators
+  https://lists.nongnu.org/archive/html/qemu-devel/2026-07/msg05455.html
+
+- [PATCH 0/4] hw/display/vmware_vga: raise resolution ceiling, advertise modern capability bits
+  https://lists.nongnu.org/archive/html/qemu-devel/2026-07/msg05453.html
+
+- [PATCH v4] powernv: boot OpenBSD on POWER9
+  https://lists.nongnu.org/archive/html/qemu-devel/2026-07/msg05445.html
+
+- [PATCH RFC v5] target/arm/kvm: Choose PMU backend
+  https://lists.nongnu.org/archive/html/qemu-devel/2026-07/msg05429.html
+
+- [PATCH 0/3] Add QTimer device
+  https://lists.nongnu.org/archive/html/qemu-devel/2026-07/msg05259.html
+
+- [PATCH 0/1] Aarch32 TCG CPU: secure register migration
+  https://lists.nongnu.org/archive/html/qemu-devel/2026-07/msg05211.html
+
+- [PATCH v4 0/3] vhost-user-gpu: Add blob resource and shared memory support
+  https://lists.nongnu.org/archive/html/qemu-devel/2026-07/msg05173.html
+
+- [PATCH v5 00/13] Add ARM64 support for MSHV accelerator
+  https://lists.nongnu.org/archive/html/qemu-devel/2026-07/msg05076.html
+
+- [PATCH] hw/9pfs: add support ORCLOSE flag to create and open request
+  https://lists.nongnu.org/archive/html/qemu-devel/2026-07/msg05040.html
+
+- [RFC PATCH v3 00/19] named CPU models for Arm64 on KVM
+  https://lists.nongnu.org/archive/html/qemu-devel/2026-07/msg04972.html
+
+- [RESEND PATCH V10 00/15] iothread: Support tracking and querying IOThread holders
+  https://lists.nongnu.org/archive/html/qemu-devel/2026-07/msg04881.html
+
+- [PATCH v10 0/2] This patch series implements VirtIO network notification coalescing
+  https://lists.nongnu.org/archive/html/qemu-devel/2026-07/msg04797.html
+
 ### RISC-V in China
 
 - https://ruyisdk.cn 每日八卦都在这里了。


### PR DESCRIPTION
Added Weekly status of upstream feature patches for QEMU as of 2026-07-22.