### PR TITLE
Add N369 QEMU News

### DIFF
--- a/weekly-2026/2026-07-29.md
+++ b/weekly-2026/2026-07-29.md
@@ -70,6 +70,81 @@ https://github.com/hellogcc/osdt-weekly/tree/master/weekly-2026
 
 ### QEMU
 
+- [PATCH 0/2] Add Model for Tenstorrent Atlantis PRCM
+  https://lists.nongnu.org/archive/html/qemu-riscv/2026-07/msg01136.html
+
+- [PATCH v1 0/3] hw/riscv: add SDHCI support for K230
+  https://lists.nongnu.org/archive/html/qemu-riscv/2026-07/msg01131.html
+
+- [PATCH] hw/timer: add k230 dwapb timer
+  https://lists.nongnu.org/archive/html/qemu-riscv/2026-07/msg01073.html
+
+- [PATCH 00/11] hw/riscv: Add K230 SPI, QSPI, IDMA and XIP support
+  https://lists.nongnu.org/archive/html/qemu-riscv/2026-07/msg01056.html
+
+- [PATCH v8 00/11] target/riscv: Implement Smsdid and Smmpt extension
+  https://lists.nongnu.org/archive/html/qemu-riscv/2026-07/msg01018.html
+
+- [PATCH 00/26] hw/riscv: Restore Microchip PolarFire SoC Icicle Kit firmware boot
+  https://lists.nongnu.org/archive/html/qemu-riscv/2026-07/msg00992.html
+
+- [PATCH v2 00/50] Introduce helper-to-tcg
+  https://lists.nongnu.org/archive/html/qemu-devel/2026-07/msg08226.html
+
+- [PATCH 00/25] hw/arm: Facebook SanMiguel BMC and TMP75-family sensors
+  https://lists.nongnu.org/archive/html/qemu-devel/2026-07/msg08105.html
+
+- [PATCH v20 00/15] virtio-net: live-TAP local migration
+  https://lists.nongnu.org/archive/html/qemu-devel/2026-07/msg08011.html
+
+- [RFC v2 00/24] Add Realm support to QEMU-VMM
+  https://lists.nongnu.org/archive/html/qemu-devel/2026-07/msg07914.html
+
+- [PATCH v5 0/6] vhost-user-blk: add compatibility with older qemu versions
+  https://lists.nongnu.org/archive/html/qemu-devel/2026-07/msg07704.html
+
+- [PATCH 0/3] accel/mshv: add gdbstub guest debugging support
+  https://lists.nongnu.org/archive/html/qemu-devel/2026-07/msg07397.html
+
+- [RFC PATCH 00/11] igb: Add experimental VF live migration support
+  https://lists.nongnu.org/archive/html/qemu-devel/2026-07/msg07218.html
+
+- [RFC PATCH v1 0/5] hw/gpio: STM32F1xx GPIO controller in Rust
+  https://lists.nongnu.org/archive/html/qemu-devel/2026-07/msg07091.html
+
+- [PATCH 0/5] hw/arm/raspi4b: RNG200 and thermal sensor
+  https://lists.nongnu.org/archive/html/qemu-devel/2026-07/msg06945.html
+
+- [PATCH 00/19] hw/arm/raspi4b: working PCIe and GENET (real networking)
+  https://lists.nongnu.org/archive/html/qemu-devel/2026-07/msg06940.html
+
+- [PATCH 0/2] target/i386: Add AMD LBR Extension v2 support
+  https://lists.nongnu.org/archive/html/qemu-devel/2026-07/msg06911.html
+
+- [PATCH 0/6] target/arm: Implement FEAT_IDTE3
+  https://lists.nongnu.org/archive/html/qemu-devel/2026-07/msg06680.html
+
+- [PATCH v4 00/15] s390x/pci: Implement migration for emulated devices
+  https://lists.nongnu.org/archive/html/qemu-devel/2026-07/msg06664.html
+
+- [PATCH 0/6] target/arm: Implement FEAT_FGWTE3
+  https://lists.nongnu.org/archive/html/qemu-devel/2026-07/msg06658.html
+
+- [PATCH 00/27] single-binary: implement dynamic filtering for machine types
+  https://lists.nongnu.org/archive/html/qemu-devel/2026-07/msg06625.html
+
+- [PATCH 0/4] arm: add Cortex-M85, SSE-310, and mps3-an555
+  https://lists.nongnu.org/archive/html/qemu-devel/2026-07/msg06620.html
+
+- [PATCH RFC 00/15] vhost-user: isolated memory
+  https://lists.nongnu.org/archive/html/qemu-devel/2026-07/msg06603.html
+
+- [PATCH 0/2] target/i386: Add missing features for Hygon Dhyana and support for Dharma
+  https://lists.nongnu.org/archive/html/qemu-devel/2026-07/msg06482.html
+
+- [PATCH for-11.2 0/3] accel/tcg: Add infrastructure for atomic 64-byte load/store
+  https://lists.nongnu.org/archive/html/qemu-devel/2026-07/msg06322.html
+
 ### RISC-V in China
 
 - https://ruyisdk.cn 每日八卦都在这里了。


### PR DESCRIPTION
Added Weekly status of upstream feature patches for QEMU as of 2026-07-29.