### PR TITLE
Add N373 QEMU News

### DIFF
--- a/weekly-2026/2026-08-26.md
+++ b/weekly-2026/2026-08-26.md
@@ -22,6 +22,60 @@ https://github.com/hellogcc/osdt-weekly/tree/master/weekly-2026
 
 ### QEMU
 
+- [PATCH 0/4] hw/riscv/virt: Add CXL support to the RISC-V virt machine
+  https://lists.nongnu.org/archive/html/qemu-riscv/2026-08/msg00829.html
+
+- [PATCH v4 0/7] hw/riscv: Add support for Milk-V Duo board
+  https://lists.nongnu.org/archive/html/qemu-riscv/2026-08/msg00861.html
+
+- [PATCH 00/13] hw/riscv, target/riscv: initial n-trace support
+  https://lists.nongnu.org/archive/html/qemu-riscv/2026-08/msg00995.html
+
+- [PATCH v2 00/13] single-binary: link ARM and RISC-V into qemu-system
+  https://lists.nongnu.org/archive/html/qemu-riscv/2026-08/msg01076.html
+
+- [PATCH v2 0/2] single-binary: implement dynamic filtering for machine types
+  https://lists.nongnu.org/archive/html/qemu-devel/2026-08/msg05275.html
+
+- [PATCH v2 0/9] Add ECDSA akcipher support and the ASPEED SBC ECDSA engine for AST10x0
+  https://lists.nongnu.org/archive/html/qemu-devel/2026-08/msg05018.html
+
+- [PATCH v2 0/4] Add ASPEED ACRY RSA model for the AST2600
+  https://lists.nongnu.org/archive/html/qemu-devel/2026-08/msg04638.html
+
+- [PATCH v4 0/8] Add Axiado SoC AX3005 and EVB
+  https://lists.nongnu.org/archive/html/qemu-devel/2026-08/msg06593.html
+
+- [PATCH RFC v2 0/5] hw/gpio: STM32F1xx GPIO controller in Rust
+  https://lists.nongnu.org/archive/html/qemu-devel/2026-08/msg05295.html
+
+- [RFC PATCH v2 00/14] hw/arm: add TI AM64x SoC and am64-virt machine
+  https://lists.nongnu.org/archive/html/qemu-devel/2026-08/msg04744.html
+
+- [PATCH v4 00/10] migration/cpr: support vhost-vsock devices
+  https://lists.nongnu.org/archive/html/qemu-devel/2026-08/msg04717.html
+
+- [PATCH 0/8] Force detach PCI devices for ACPI-based and PCIe native hot-unplug
+  https://lists.nongnu.org/archive/html/qemu-devel/2026-08/msg05411.html
+
+- [PATCH 0/5] Add Multiple Atomicity Mode (MAM) support
+  https://lists.nongnu.org/archive/html/qemu-devel/2026-08/msg06398.html
+
+- [PATCH 0/5] target/i386: Add support for LASS
+  https://lists.nongnu.org/archive/html/qemu-devel/2026-08/msg06530.html
+
+- [PATCH v2 0/3] vfio-user: support multiple FDs backing region mmaps
+  https://lists.nongnu.org/archive/html/qemu-devel/2026-08/msg06536.html
+
+- [PATCH v3 0/4] target/arm: Introduce cpu types max-v8 and max-v9
+  https://lists.nongnu.org/archive/html/qemu-devel/2026-08/msg06435.html
+
+- [PATCH v2 0/3] Extend secure IPL support to virtio-blk-pci boot devices
+  https://lists.nongnu.org/archive/html/qemu-devel/2026-08/msg06862.html
+
+- [RFC V2 0/9] hw/pci: hw/cxl: Add UIO support in CXL and PCIe stack.
+  https://lists.nongnu.org/archive/html/qemu-devel/2026-08/msg06620.html
+
 ### RISC-V in China
 
 - https://ruyisdk.cn 每日八卦都在这里了。
@@ -47,4 +101,3 @@ https://github.com/hellogcc/osdt-weekly/tree/master/weekly-2026
 译者：
 
 推荐：
-


### PR DESCRIPTION
Added Weekly status of upstream feature patches for QEMU as of 2026-08-26.