### PR TITLE
[开源自荐] 为第376期添加 NanoAvatar 手机端数字人项目

### DIFF
--- a/weekly-2026/2026-09-16.md
+++ b/weekly-2026/2026-09-16.md
@@ -7,6 +7,9 @@ https://github.com/hellogcc/osdt-weekly/tree/master/weekly-2026
 
 ## 编译社区的八卦信息
 
+- 【开源自荐】[NanoAvatar](https://github.com/wpydcr/NanoAvatar)：在 Android 手机上本地生成语音驱动的数字人视频，无需云端 GPU。支持流式生成，已发布 Android 与 Web 推理源码、模型权重和可安装 APK。
+  [演示](https://github.com/wpydcr/NanoAvatar#demo) · [模型权重](https://huggingface.co/wpydcr/NanoAvatar) · [Android APK](https://github.com/wpydcr/NanoAvatar/releases/latest)
+
 ### GCC
 
 ### BINUTILS


### PR DESCRIPTION
在第 376 期（2026-09-16）的“编译社区的八卦信息”栏目添加 NanoAvatar 开源项目自荐，沿用近期周报中项目自荐的位置。

NanoAvatar 在 Android 手机上本地生成语音驱动的数字人视频，支持流式推理，无需云端 GPU。已发布 Android 与 Web 推理源码、模型权重及可安装 APK。Android 的 Experience 模式可以直接录音并离线体验，无需 API key。

我是项目作者。供审核的链接：

- [GitHub 源码](https://github.com/wpydcr/NanoAvatar)
- [视频演示](https://github.com/wpydcr/NanoAvatar#demo)
- [模型权重](https://huggingface.co/wpydcr/NanoAvatar)
- [Android APK](https://github.com/wpydcr/NanoAvatar/releases/latest)

已检查当前仓库与现有 PR，没有找到 NanoAvatar 重复条目。本次只补充该项目的信息。